### PR TITLE
Fixed LINQ expressions using a string would be evaluated locally

### DIFF
--- a/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
@@ -101,7 +101,8 @@ namespace MySQL.Data.Entity
 				{ typeof(short), _smallint },
 				{ typeof(float), _real },
 				{ typeof(decimal), _decimal },
-				{ typeof(byte[]), _varbinary }
+				{ typeof(byte[]), _varbinary },
+				{ typeof(string), _varchar }
 			};
 		}
 

--- a/src/SapientGuardian.EntityFrameworkCore.MySql/project.json
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.0",
+  "version": "7.1.3",
   "description": "MySQL database provider for Entity Framework Core.",
   "authors": [ "how02", "SapientGuardian" ],
   "buildOptions": {


### PR DESCRIPTION
This code:

```
public Task<UserGroup> GetUserGroup(string groupTitle)
{
    return UsersGroups.SingleOrDefaultAsync(ug => ug.title == groupTitle);
}
```

Would generate this warning:

> Microsoft.EntityFrameworkCore.Query.RelationalQueryCompilationContextFactory:Warning: The LINQ expression '([u].username == __userName_0)' could not be translated and will be evaluated locally.

This PR fix the issue.
