### PR TITLE
LINQ to SQL Contains translation using DbParameter

### DIFF
--- a/src/SapientGuardian.EntityFrameworkCore.MySql/Query/ExpressionTranslators/MySqlContainsTranslator.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/Query/ExpressionTranslators/MySqlContainsTranslator.cs
@@ -10,25 +10,14 @@ namespace SapientGuardian.MySql.Data.EntityFrameworkCore.Query.ExpressionTransla
     {
         private static readonly MethodInfo MethodInfo = typeof(string).GetRuntimeMethod("Contains", new[] { typeof(string) });
 
-        private static readonly MethodInfo Format = typeof(string).GetRuntimeMethod("Format", new[]
-        {
-              typeof (string),
-              typeof (object)
-            });
-
         public override Expression Translate(MethodCallExpression methodCallExpression)
         {
-            //    Expression.Coalesce(Expression.Add(
-            //                Expression.Add(Expression.Constant("%", typeof(string)),
-            //                    methodCallExpression.Arguments[0], Concat),
-            //                Expression.Constant("{0}%", typeof(string)), Concat),
-            //    Expression.Constant(string.Empty, typeof(string)))
             if (methodCallExpression == null) throw new ArgumentNullException(nameof(methodCallExpression));
             return methodCallExpression.Method != MethodInfo
                 ? null
                 : new LikeExpression(
                     methodCallExpression.Object,
-                    Expression.Call(Format, Expression.Constant("%{0}%", typeof(string)), methodCallExpression.Arguments[0])
+                    methodCallExpression.Arguments[0]
                 );
         }
     }

--- a/src/SapientGuardian.EntityFrameworkCore.MySql/project.json
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.5",
+  "version": "7.1.6",
   "description": "MySQL database provider for Entity Framework Core.",
   "authors": [ "how02", "SapientGuardian" ],
   "buildOptions": {


### PR DESCRIPTION
Hi everyone,
this pull request resolve a cache problem of LIKE expression generated by #16.

In addition, this version uses DbParameter which convert special char (eg. ') in theirs escaped sequence.
