### PR TITLE
Fixed CAST and CONCAT expressions

### DIFF
--- a/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
@@ -20,12 +20,12 @@
 // with this program; if not, write to the Free Software Foundation, Inc., 
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore;
 
 namespace MySQL.Data.Entity
 {
@@ -47,18 +47,24 @@ namespace MySQL.Data.Entity
 		private readonly RelationalTypeMapping _Text = new RelationalTypeMapping("text", typeof(String));
 		private readonly RelationalTypeMapping _tinyText = new RelationalTypeMapping("tinytext", typeof(String));
 
-		private readonly RelationalTypeMapping _varchar = new RelationalTypeMapping("varchar(1000)", typeof(String), DbType.AnsiString, false, 1000);
-		private readonly RelationalTypeMapping _varbinary = new RelationalTypeMapping("blob", typeof(byte[]));
-		private readonly RelationalTypeMapping _datetime = new RelationalTypeMapping("datetime", typeof(DateTime));
-		private readonly RelationalTypeMapping _date = new RelationalTypeMapping("date", typeof(DateTime));
-		private readonly RelationalTypeMapping _time = new RelationalTypeMapping("time", typeof(DateTime));
+		private readonly RelationalTypeMapping _varchar = new RelationalTypeMapping("varchar(255)", typeof(String), DbType.AnsiString, false, 255);
+		private readonly RelationalTypeMapping _varbinary = new RelationalTypeMapping("blob", typeof(byte[]), DbType.Binary);
+		private readonly RelationalTypeMapping _datetime = new RelationalTypeMapping("datetime", typeof(DateTime), DbType.DateTime);
+		private readonly RelationalTypeMapping _date = new RelationalTypeMapping("date", typeof(DateTime), DbType.Date);
+		private readonly RelationalTypeMapping _time = new RelationalTypeMapping("time", typeof(TimeSpan), DbType.Time);
 		private readonly RelationalTypeMapping _double = new RelationalTypeMapping("float", typeof(Single));
 		private readonly RelationalTypeMapping _real = new RelationalTypeMapping("real", typeof(Single));
 		private readonly RelationalTypeMapping _decimal = new RelationalTypeMapping("decimal(18, 2)", typeof(Decimal));
 
+		private readonly RelationalTypeMapping _cast_binary = new RelationalTypeMapping("BINARY(255)", typeof(byte[]), DbType.Binary);
+		private readonly RelationalTypeMapping _cast_char = new RelationalTypeMapping("CHAR(255)", typeof(string), DbType.AnsiString, false, 255);
+		private readonly RelationalTypeMapping _cast_datetime = new RelationalTypeMapping("DATETIME", typeof(DateTime), DbType.DateTime);
+		private readonly RelationalTypeMapping _cast_signed = new RelationalTypeMapping("SIGNED", typeof(long));
+		private readonly RelationalTypeMapping _cast_unsigned = new RelationalTypeMapping("UNSIGNED", typeof(ulong));
 
 		private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
 		private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
+		private readonly Dictionary<Type, RelationalTypeMapping> _clrCastTypeMappings;
 
 		public MySQLTypeMapper()
 		{
@@ -90,6 +96,7 @@ namespace MySQL.Data.Entity
 				{ typeof(int), _int },
 				{ typeof(long), _bigint },
 				{ typeof(DateTime), _datetime },
+				{ typeof(TimeSpan), _time },
 				{ typeof(bool), _bit },
 				{ typeof(byte), _tinyint },
 				{ typeof(double), _double },
@@ -103,6 +110,21 @@ namespace MySQL.Data.Entity
 				{ typeof(decimal), _decimal },
 				{ typeof(byte[]), _varbinary },
 				{ typeof(string), _varchar }
+			};
+
+			_clrCastTypeMappings = new Dictionary<Type, RelationalTypeMapping>
+			{
+				{ typeof(byte[]), _cast_binary },
+				{ typeof(string), _cast_char },
+				{ typeof(DateTime), _cast_datetime },
+				{ typeof(char), _cast_signed },
+				{ typeof(short), _cast_signed },
+				{ typeof(int), _cast_signed },
+				{ typeof(long), _cast_signed },
+				{ typeof(byte), _cast_unsigned },
+				{ typeof(ushort), _cast_unsigned },
+				{ typeof(uint), _cast_unsigned },
+				{ typeof(ulong), _cast_unsigned }
 			};
 		}
 
@@ -136,6 +158,14 @@ namespace MySQL.Data.Entity
 				return _varbinary;
 
 			return base.FindCustomMapping(property);
+		}
+
+		public RelationalTypeMapping FindMappingForExplicitCast(Type clrType)
+		{
+			RelationalTypeMapping mapping;
+			return _clrCastTypeMappings.TryGetValue(clrType, out mapping)
+				? mapping
+				: null;
 		}
 	}
 }

--- a/src/SapientGuardian.EntityFrameworkCore.MySql/Query/MySQLQuerySqlGenerator.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/Query/MySQLQuerySqlGenerator.cs
@@ -32,22 +32,8 @@ namespace MySQL.Data.Entity.Query
 {
 	public class MySQLQuerySqlGenerator : DefaultQuerySqlGenerator
 	{
-		protected override string TypedFalseLiteral
-		{
-			get
-			{
-				return "('0')";
-			}
-		}
-
-
-		protected override string TypedTrueLiteral
-		{
-			get
-			{
-				return "('1')";
-			}
-		}
+		protected override string TypedFalseLiteral => "('0')";
+		protected override string TypedTrueLiteral => "('1')";
 
 		private MySQLTypeMapper _typeMapper;
 
@@ -93,7 +79,7 @@ namespace MySQL.Data.Entity.Query
 			if(typeMapping == null)
 				throw new InvalidOperationException(RelationalStrings.UnsupportedType(explicitCastExpression.Type.Name));
 
-			Sql.Append(" CAST(");
+			Sql.Append("CAST(");
 			Visit(explicitCastExpression.Operand);
 			Sql.Append(" AS ");
 			Sql.Append(typeMapping.StoreType);
@@ -111,5 +97,21 @@ namespace MySQL.Data.Entity.Query
 
 	        return likeExpression;
 	    }
-    }
+
+		protected override Expression VisitBinary(BinaryExpression expression)
+		{
+			if(expression.NodeType == ExpressionType.Add && expression.Type == typeof(string))
+			{
+				Sql.Append("CONCAT(");
+				Visit(expression.Left);
+				Sql.Append(", ");
+				Visit(expression.Right);
+				Sql.Append(")");
+
+				return expression;
+			}
+
+			return base.VisitBinary(expression);
+		}
+	}
 }


### PR DESCRIPTION
Using this code:

```
_ipbDb.Purchases
    .Join(_ipbDb.Packages, pur => pur.PackageId, pack => pack.Id, (pur, pack) => new { Purchase = pur, Package = pack })
    .Join(_ipbDb.SystemLangWords, pur => "nexus_package_" + pur.Package.Id, slw => slw.Key, (pur, slw) => new { Purchase = pur.Purchase, Package = pur.Package, Lang = slw })
    .Where(e => e.Purchase.UserId == userId && e.Purchase.Active && timestamp >= e.Purchase.TimeBegin && timestamp < e.Purchase.TimeEnd)
    .Select(e => new { ProductId = e.Package.Id, ProductName = e.Lang.Custom ?? e.Lang.Default, GameId = e.Package.GroupId })
    .ToList();
```

In the current implementation, the generated SQL query is invalid (CAST to an unsupported type, CONCAT not present):

```
SELECT `pack`.`p_id`, COALESCE(`slw`.`word_custom`, `slw`.`word_default`) AS `Coalesce`, `pack`.`p_group`
FROM `nexus_purchases` AS `pur`
INNER JOIN `nexus_packages` AS `pack` ON `pur`.`ps_item_id` = `pack`.`p_id`
INNER JOIN `core_sys_lang_words` AS `slw` ON ('nexus_package_' + CAST(`pack`.`p_id` AS varchar(1000))) = `slw`.`word_key`
WHERE (((`pur`.`ps_member` = 3) AND (`pur`.`ps_active` = 1)) AND (1474456669 >= `pur`.`ps_start`)) AND (1474456669 < `pur`.`ps_expire`)
```

With this PR, the generated SQL query is now valid:

```
SELECT `pack`.`p_id`, COALESCE(`slw`.`word_custom`, `slw`.`word_default`) AS `Coalesce`, `pack`.`p_group`
FROM `nexus_purchases` AS `pur`
INNER JOIN `nexus_packages` AS `pack` ON `pur`.`ps_item_id` = `pack`.`p_id`
INNER JOIN `core_sys_lang_words` AS `slw` ON (CONCAT('nexus_package_', CAST(`pack`.`p_id` AS CHAR(255)))) = `slw`.`word_key`
WHERE (((`pur`.`ps_member` = 3) AND (`pur`.`ps_active` = 1)) AND (1474455524 >= `pur`.`ps_start`)) AND (1474455524 < `pur`.`ps_expire`)
```
