### PR TITLE
CLR type System.Guid mapping and boolean conversion

### DIFF
--- a/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
@@ -64,7 +64,7 @@ namespace MySQL.Data.Entity
 		private readonly RelationalTypeMapping _cast_signed = new RelationalTypeMapping("SIGNED", typeof(long));
 		private readonly RelationalTypeMapping _cast_unsigned = new RelationalTypeMapping("UNSIGNED", typeof(ulong));
 
-        private readonly RelationalTypeMapping _guid = new RelationalTypeMapping("varchar(40)", typeof(Guid), DbType.String, true, null);
+        private readonly RelationalTypeMapping _guid = new RelationalTypeMapping("CHAR(36)", typeof(Guid), DbType.String, true, null);
 
         private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
 		private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;

--- a/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/MySQLTypeMapper.cs
@@ -64,7 +64,9 @@ namespace MySQL.Data.Entity
 		private readonly RelationalTypeMapping _cast_signed = new RelationalTypeMapping("SIGNED", typeof(long));
 		private readonly RelationalTypeMapping _cast_unsigned = new RelationalTypeMapping("UNSIGNED", typeof(ulong));
 
-		private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
+        private readonly RelationalTypeMapping _guid = new RelationalTypeMapping("varchar(40)", typeof(Guid), DbType.String, true, null);
+
+        private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
 		private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
 		private readonly Dictionary<Type, RelationalTypeMapping> _clrCastTypeMappings;
 
@@ -112,8 +114,9 @@ namespace MySQL.Data.Entity
 				{ typeof(float), _real },
 				{ typeof(decimal), _decimal },
 				{ typeof(byte[]), _varbinary },
-				{ typeof(string), _varchar }
-			};
+				{ typeof(string), _varchar },
+                { typeof(Guid), _guid }
+            };
 
 			_clrCastTypeMappings = new Dictionary<Type, RelationalTypeMapping>
 			{
@@ -163,7 +166,12 @@ namespace MySQL.Data.Entity
 			if(property.ClrType == typeof(byte[]))
 				return _varbinary;
 
-			return base.FindCustomMapping(property);
+            if (property.ClrType == typeof(Guid))
+                return this._guid;
+
+
+
+            return base.FindCustomMapping(property);
 		}
 
 		public RelationalTypeMapping FindMappingForExplicitCast(Type clrType)

--- a/src/SapientGuardian.EntityFrameworkCore.MySql/Query/MySQLQuerySqlGenerator.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/Query/MySQLQuerySqlGenerator.cs
@@ -32,8 +32,8 @@ namespace MySQL.Data.Entity.Query
 {
 	public class MySQLQuerySqlGenerator : DefaultQuerySqlGenerator
 	{
-		protected override string TypedFalseLiteral => "('0')";
-		protected override string TypedTrueLiteral => "('1')";
+		protected override string TypedFalseLiteral => "0";
+        protected override string TypedTrueLiteral => "1";
 
 		private MySQLTypeMapper _typeMapper;
 

--- a/src/SapientGuardian.EntityFrameworkCore.MySql/project.json
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.9",
+  "version": "7.1.10-prerelease",
   "description": "MySQL database provider for Entity Framework Core.",
   "authors": [ "how02", "SapientGuardian" ],
   "buildOptions": {


### PR DESCRIPTION
Hi,
This pull request adds the CLR type **System.Guid** to MySQLTypeMapper with **char(36)** storage type, as suggested in #20, and solves the thrown exception using **Any** linq method. Below you'll find message and stack-trace of the exception:

"String was not recognized as a valid Boolean." 
at System.Boolean.Parse(String value)
at System.String.System.IConvertible.ToBoolean(IFormatProvider provider)
at lambda_method(Closure , DbDataReader )
at Microsoft.EntityFrameworkCore.Storage.Internal.TypedRelationalValueBufferFactory.Create(DbDataReader dataReader)
at Microsoft.EntityFrameworkCore.Query.Internal.AsyncQueryingEnumerable.AsyncEnumerator.d__8.MoveNext().
Plus, this pull contains the version pump to 7.1.10-prerelease
