### PR TITLE
Override update methods to fix empty model problem

### DIFF
--- a/src/SapientGuardian.EntityFrameworkCore.MySql/Update/MySQLUpdateSqlGenerator.cs
+++ b/src/SapientGuardian.EntityFrameworkCore.MySql/Update/MySQLUpdateSqlGenerator.cs
@@ -23,15 +23,39 @@
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using System.Text;
+using System.Collections.Generic;
 
 namespace MySQL.Data.Entity
 {
 	public class MySQLUpdateSqlGenerator : UpdateSqlGenerator
 	{
-
-		public MySQLUpdateSqlGenerator( ISqlGenerationHelper sqlGenerator)
+		public MySQLUpdateSqlGenerator(ISqlGenerationHelper sqlGenerator)
 				: base(sqlGenerator)
 		{ }
+
+		protected override void AppendValues(StringBuilder commandStringBuilder, IReadOnlyList<ColumnModification> operations) 
+		{ 
+			ThrowIf.Argument.IsNull(commandStringBuilder, "commandStringBuilder"); 
+			ThrowIf.Argument.IsNull(operations, "operations"); 
+ 
+			if (operations.Count > 0) 
+			{ 
+				base.AppendValues(commandStringBuilder, operations); 
+			} 
+			else 
+			{ 
+				commandStringBuilder.Append("()"); 
+			} 
+		} 
+ 
+		protected override void AppendValuesHeader(StringBuilder commandStringBuilder, IReadOnlyList<ColumnModification> operations) 
+		{ 
+			ThrowIf.Argument.IsNull(commandStringBuilder, "commandStringBuilder"); 
+ 			ThrowIf.Argument.IsNull(operations, "operations"); 
+ 
+			commandStringBuilder.AppendLine(); 
+			commandStringBuilder.Append("VALUES "); 
+		} 
 
 		protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, ColumnModification columnModification)
 		{


### PR DESCRIPTION
The SQL generated by the base update class doesn't work for MySQL, this overrides the necessary updates to change the SQL generated for the case where the model only has an ID field.

This fixes issues #44 by overriding key methods to behave differently when no fields are used.